### PR TITLE
Fix MySQL setup

### DIFF
--- a/docker-compose-standalone.yml
+++ b/docker-compose-standalone.yml
@@ -7,14 +7,14 @@ services:
     command: [mysqld, --character-set-server=utf8mb4, --collation-server=utf8mb4_unicode_ci, --default-authentication-plugin=mysql_native_password]
     volumes:
       - ./mysql:/var/lib/mysql
-      - ./mysql/custom:/etc/mysql/conf.d
+      - ./mysql-custom:/etc/mysql/conf.d
       - ./setup.sql:/docker-entrypoint-initdb.d/setup.sql
     environment:
       - MYSQL_ROOT_PASSWORD=${AA_DB_ROOT_PASSWORD}
     networks:
       - aa-network
     healthcheck:
-      test: ["CMD", "mysqladmin", "-uroot", "-proot", "-h", "localhost", "ping"]
+      test: ["CMD", "mysqladmin", "-uroot", "-p`${AA_DB_ROOT_PASSWORD}`", "-h", "localhost", "ping"]
       interval: 5s
       timeout: 10s
       retries: 3
@@ -73,7 +73,7 @@ services:
       DB_PASSWORD: "${AA_DB_PASSWORD}"
     volumes:
       - ./conf/local.py:/home/allianceserver/myauth/myauth/settings/local.py
-      - ./templates:/home/allianceserver//myauth/myauth/templates/
+      - ./templates:/home/allianceserver/myauth/myauth/templates/
       - static-volume:/var/www/myauth/static
     depends_on:
      - redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,14 +7,14 @@ services:
     command: [mysqld, --character-set-server=utf8mb4, --collation-server=utf8mb4_unicode_ci, --default-authentication-plugin=mysql_native_password]
     volumes:
       - ./mysql:/var/lib/mysql
-      - ./mysql/custom:/etc/mysql/conf.d
+      - ./mysql-custom:/etc/mysql/conf.d
       - ./setup.sql:/docker-entrypoint-initdb.d/setup.sql
     environment:
       - MYSQL_ROOT_PASSWORD=${AA_DB_ROOT_PASSWORD}
     networks:
       - aa-network
     healthcheck:
-      test: ["CMD", "mysqladmin", "-uroot", "-proot", "-h", "localhost", "ping"]
+      test: ["CMD", "mysqladmin", "-uroot", "-p`${AA_DB_ROOT_PASSWORD}`", "-h", "localhost", "ping"]
       interval: 5s
       timeout: 10s
       retries: 3
@@ -73,7 +73,7 @@ services:
       DB_PASSWORD: "${AA_DB_PASSWORD}"
     volumes:
       - ./conf/local.py:/home/allianceserver/myauth/myauth/settings/local.py
-      - ./templates:/home/allianceserver//myauth/myauth/templates/
+      - ./templates:/home/allianceserver/myauth/myauth/templates/
       - static-volume:/var/www/myauth/static
     depends_on:
      - redis
@@ -83,7 +83,6 @@ services:
 
 networks:
   t2_proxy:
-    external: true
   aa-network:
 
 volumes:

--- a/mysql-custom/my.cnf
+++ b/mysql-custom/my.cnf
@@ -1,0 +1,2 @@
+[mysqld]
+default-authentication-plugin=mysql_native_password

--- a/setup.sql
+++ b/setup.sql
@@ -1,3 +1,3 @@
-CREATE USER 'aauth'@'localhost' IDENTIFIED BY 'PASSWORD';
+CREATE USER 'aauth'@'localhost' IDENTIFIED WITH mysql_native_password BY 'PASSWORD';
 CREATE DATABASE aauth CHARACTER SET utf8mb4;
-GRANT ALL PRIVILEGES ON alliance_auth . * TO 'aauth'@'localhost';
+GRANT ALL PRIVILEGES ON aauth . * TO 'aauth'@'localhost';


### PR DESCRIPTION
- /var/lib/mysql volume fails to create if the local directory isn't empty; moved custom folder
- healthcheck now uses the proper root password
- setup.sql creates user with `mysql_native_password` enabled
- custom my.cnf also enables `mysql_native_password`